### PR TITLE
GetterMapFix

### DIFF
--- a/headers/builder/command-validation/CmdSpec.hpp
+++ b/headers/builder/command-validation/CmdSpec.hpp
@@ -107,27 +107,27 @@ class CmdSpec {
 };
 
 //JOIN
-void handleJoin(CmdSpec &cmd);
+void joinExec(CmdSpec &cmd);
 Channel *createChan(const std::string &chanName);
 
 //MODE
-void handleMode(CmdSpec &cmd);
+void modeExec(CmdSpec &cmd);
 typedef void (*modesFunc)(std::string flag, std::string param, Channel &curChan);
 
 //TOPIC
-void handleTopic(CmdSpec &cmd);
+void topicExec(CmdSpec &cmd);
 
 //INVITE
-void handleInvite(CmdSpec &cmd);
+void inviteExec(CmdSpec &cmd);
 
 //KICK
-void handleKick(CmdSpec &cmd);
+void kickExec(CmdSpec &cmd);
 
 //PART
-void handlePart(CmdSpec &cmd);
+void partExec(CmdSpec &cmd);
 
 //PRIVMSG
-void handlePrivsmg(CmdSpec &cmd);
+void privmsgExec(CmdSpec &cmd);
 
 //UTILS
 Channel &findCurChan(std::string chanName);

--- a/headers/server/Channel.hpp
+++ b/headers/server/Channel.hpp
@@ -6,7 +6,7 @@
 /*   By: aljulien < aljulien@student.42lyon.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/26 14:31:38 by aljulien          #+#    #+#             */
-/*   Updated: 2025/03/19 16:14:54 by aljulien         ###   ########.fr       */
+/*   Updated: 2025/03/20 11:04:25 by aljulien         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -37,9 +37,9 @@ class Channel {
 	bool getInviteOnly() const;
 	bool getIsPassMatch() const;
 	bool getTopicRestrict() const;
-	clientMap &getCliInChan();
-	clientMap &getOpCli();
-	clientMap &getInvitCli();
+	const clientMap &getCliInChan() const;
+	const clientMap &getOpCli() const;
+	const clientMap &getInvitCli() const;
 	int getMaxCli() const;
 	std::string getName() const;
 	std::string getTopic() const;

--- a/headers/server/Channel.hpp
+++ b/headers/server/Channel.hpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   Channel.hpp                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: aljulien <aljulien@student.42.fr>          +#+  +:+       +#+        */
+/*   By: aljulien < aljulien@student.42lyon.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/26 14:31:38 by aljulien          #+#    #+#             */
-/*   Updated: 2025/03/18 17:00:10 by aljulien         ###   ########.fr       */
+/*   Updated: 2025/03/19 16:14:54 by aljulien         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,6 +16,8 @@
 #include "Client.hpp"
 #include "Reply.hpp"
 #include "typedef.hpp"
+
+enum mapChan { ALLCLI, OPCLI, INVITECLI };
 
 class Client;
 
@@ -28,6 +30,8 @@ class Channel {
 	/*                               METHODS                                  */
 	bool addClientToChan(Channel *curChan, Client *curCli);
 	void printMapValues();
+	void addCli(mapChan curMap, Client *curCli);
+	void removeCli(mapChan curMap, int fdCli);
 
 	/*                               GETTERS                                  */
 	bool getInviteOnly() const;

--- a/headers/server/Server.hpp
+++ b/headers/server/Server.hpp
@@ -6,7 +6,7 @@
 /*   By: aljulien < aljulien@student.42lyon.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/18 15:25:50 by aljulien          #+#    #+#             */
-/*   Updated: 2025/03/20 10:41:22 by aljulien         ###   ########.fr       */
+/*   Updated: 2025/03/20 11:11:07 by aljulien         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -58,8 +58,8 @@ class Server {
 	void removeChan(Channel *curChan);
 
 	/*                               GETTERS                                  */
-	clientMap &getAllCli();
-	channelMap &getAllChan();
+	const clientMap &getAllCli() const;
+	const channelMap &getAllChan() const;
 	std::string getPass() const;
 
   private:

--- a/headers/server/Server.hpp
+++ b/headers/server/Server.hpp
@@ -6,7 +6,7 @@
 /*   By: aljulien < aljulien@student.42lyon.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/18 15:25:50 by aljulien          #+#    #+#             */
-/*   Updated: 2025/03/19 16:41:27 by aljulien         ###   ########.fr       */
+/*   Updated: 2025/03/20 10:41:22 by aljulien         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -90,11 +90,11 @@ class Server {
 void handleClientRegistration(const std::string &input, Client *curCli);
 
 //PRIVMSG
-bool handlePrivsmg(std::string params, Client *curCli);
+bool privmsgExec(std::string params, Client *curCli);
 //WHO
-bool handleWho(std::string params, Client *curCli);
+bool whoExec(std::string params, Client *curCli);
 //PASS
-bool handlePass(std::string params, Client *curCli);
+bool passExec(std::string params, Client *curCli);
 
 /*                               DEBUG                                  */
 void logLevel(logEnum level, std::string message);

--- a/headers/server/Server.hpp
+++ b/headers/server/Server.hpp
@@ -6,7 +6,7 @@
 /*   By: aljulien < aljulien@student.42lyon.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/18 15:25:50 by aljulien          #+#    #+#             */
-/*   Updated: 2025/03/19 15:45:01 by aljulien         ###   ########.fr       */
+/*   Updated: 2025/03/19 16:41:27 by aljulien         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -54,10 +54,8 @@ class Server {
 	bool servRun();
 	void acceptClient();
 	void processBuffer(Client *curCli);
-	void addCli(int fdCli);
-	void removeCli(int fdCli);
-	void addChan(std::string nameChan);
-	void removeChan(std::string nameChan);
+	void addChan(Channel *curChan);
+	void removeChan(Channel *curChan);
 
 	/*                               GETTERS                                  */
 	clientMap &getAllCli();

--- a/headers/server/Server.hpp
+++ b/headers/server/Server.hpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   Server.hpp                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: aljulien <aljulien@student.42.fr>          +#+  +:+       +#+        */
+/*   By: aljulien < aljulien@student.42lyon.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/18 15:25:50 by aljulien          #+#    #+#             */
-/*   Updated: 2025/03/18 17:00:17 by aljulien         ###   ########.fr       */
+/*   Updated: 2025/03/19 15:45:01 by aljulien         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -54,6 +54,10 @@ class Server {
 	bool servRun();
 	void acceptClient();
 	void processBuffer(Client *curCli);
+	void addCli(int fdCli);
+	void removeCli(int fdCli);
+	void addChan(std::string nameChan);
+	void removeChan(std::string nameChan);
 
 	/*                               GETTERS                                  */
 	clientMap &getAllCli();

--- a/headers/typedef.hpp
+++ b/headers/typedef.hpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   typedef.hpp                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: aljulien <aljulien@student.42.fr>          +#+  +:+       +#+        */
+/*   By: aljulien < aljulien@student.42lyon.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: Invalid date        by                   #+#    #+#             */
-/*   Updated: 2025/03/18 17:00:19 by aljulien         ###   ########.fr       */
+/*   Updated: 2025/03/20 11:11:49 by aljulien         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,9 +23,9 @@ class Channel;
 // -------------------------------- DATA TYPES ------------------------------ //
 
 typedef std::map< int, Client * > clientMap;
-typedef std::map< int, Client * >::iterator clientMapIt;
+typedef std::map< int, Client * >::const_iterator clientMapIt;
 typedef std::map< std::string, Channel * > channelMap;
-typedef std::map< std::string, Channel * >::iterator channelMapIt;
+typedef std::map< std::string, Channel * >::const_iterator channelMapIt;
 typedef std::pair< int, Client * > clientPair;
 typedef std::vector< std::string > stringVec;
 

--- a/notes.txt
+++ b/notes.txt
@@ -12,6 +12,7 @@ PRIVMSG, USER, NICK, JOIN, TOPIC, WHO, PART, KICK, QUIT, INVITE, PASS, MODE //cu
 toutes les functions d'exec prennent reference d'une instance de CmdSpec
 Faire headers exec pour function 
 Faire message reply modes`
+Erase Channel if nobody there (delete empty channel)
 
 TRAME :
 

--- a/src/builder/command-execution/Invite.cpp
+++ b/src/builder/command-execution/Invite.cpp
@@ -6,7 +6,7 @@
 /*   By: aljulien < aljulien@student.42lyon.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/13 10:03:32 by aljulien          #+#    #+#             */
-/*   Updated: 2025/03/19 16:13:44 by aljulien         ###   ########.fr       */
+/*   Updated: 2025/03/20 10:41:54 by aljulien         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,7 +14,7 @@
 #include "Reply.hpp"
 #include "Server.hpp"
 
-void handleInvite(CmdSpec &cmd)
+void inviteExec(CmdSpec &cmd)
 {
 	static Server &server = Server::GetServerInstance(0, "");
 	Channel &curChan = findCurChan(cmd[channel][0]);

--- a/src/builder/command-execution/Invite.cpp
+++ b/src/builder/command-execution/Invite.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   Invite.cpp                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: aljulien <aljulien@student.42.fr>          +#+  +:+       +#+        */
+/*   By: aljulien < aljulien@student.42lyon.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/13 10:03:32 by aljulien          #+#    #+#             */
-/*   Updated: 2025/03/19 12:49:06 by aljulien         ###   ########.fr       */
+/*   Updated: 2025/03/19 16:13:44 by aljulien         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,5 +33,5 @@ void handleInvite(CmdSpec &cmd)
 	sendReply(targetCli->getFd(),
 			  RPL_INVITE(sender->cliInfo.getNick(),
 						 targetCli->cliInfo.getNick(), cmd[channel][0]));
-	curChan.getInvitCli().insert(clientPair(targetCli->getFd(), targetCli));
+	curChan.addCli(INVITECLI, targetCli);
 }

--- a/src/builder/command-execution/Join.cpp
+++ b/src/builder/command-execution/Join.cpp
@@ -6,7 +6,7 @@
 /*   By: aljulien < aljulien@student.42lyon.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/04 16:49:32 by aljulien          #+#    #+#             */
-/*   Updated: 2025/03/19 16:42:37 by aljulien         ###   ########.fr       */
+/*   Updated: 2025/03/20 10:41:33 by aljulien         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,14 +34,14 @@ Channel *createChan(const std::string &chanName)
 {
 	for (stringVec::iterator currChanName = curCli->getJoinedChans().begin();
 		 currChanName != curCli->getJoinedChans().end(); ++currChanName) {
-		handlePart(*currChanName, curCli);
+		partExec(*currChanName, curCli);
 	}
 	curCli->getJoinedChans().clear();
 } */
 
-void handleJoin(CmdSpec &cmd)
+void joinExec(CmdSpec &cmd)
 {
-	logLevel(DEBUG, "-----handleJoin-----");
+	logLevel(DEBUG, "-----joinExec-----");
 	Client *sender = &cmd.getSender();
 	if (cmd[channel][0] == "0") {
 		//partAllChans(sender);

--- a/src/builder/command-execution/Join.cpp
+++ b/src/builder/command-execution/Join.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   Join.cpp                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: aljulien <aljulien@student.42.fr>          +#+  +:+       +#+        */
+/*   By: aljulien < aljulien@student.42lyon.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/04 16:49:32 by aljulien          #+#    #+#             */
-/*   Updated: 2025/03/18 17:04:20 by aljulien         ###   ########.fr       */
+/*   Updated: 2025/03/19 16:42:37 by aljulien         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,8 +26,7 @@ Channel *createChan(const std::string &chanName)
 	Channel *newChan = new Channel(chanName);
 	newChan->setName(chanName);
 	newChan->setModes();
-	server.getAllChan().insert(
-		std::pair< std::string, Channel * >(newChan->getName(), newChan));
+	server.addChan(newChan);
 	return (newChan);
 }
 

--- a/src/builder/command-execution/Kick.cpp
+++ b/src/builder/command-execution/Kick.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   Kick.cpp                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: aljulien <aljulien@student.42.fr>          +#+  +:+       +#+        */
+/*   By: aljulien < aljulien@student.42lyon.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/13 16:52:14 by aljulien          #+#    #+#             */
-/*   Updated: 2025/03/19 12:49:49 by aljulien         ###   ########.fr       */
+/*   Updated: 2025/03/19 16:34:03 by aljulien         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,14 +18,14 @@ void kickFromAllMap(Client *target, Channel &curChan)
 {
 	int fdTarget = target->getFd();
 
-	curChan.getCliInChan().erase(fdTarget);
+	curChan.removeCli(ALLCLI, fdTarget);
 	clientMapIt itTarget;
 	itTarget = curChan.getOpCli().find(fdTarget);
 	if (itTarget != curChan.getOpCli().end())
-		curChan.getOpCli().erase(fdTarget);
+		curChan.removeCli(OPCLI, fdTarget);
 	itTarget = curChan.getInvitCli().find(fdTarget);
 	if (itTarget != curChan.getInvitCli().end())
-		curChan.getInvitCli().erase(fdTarget);
+		curChan.removeCli(INVITECLI, fdTarget);
 }
 
 void handleKick(CmdSpec &cmd)

--- a/src/builder/command-execution/Kick.cpp
+++ b/src/builder/command-execution/Kick.cpp
@@ -6,7 +6,7 @@
 /*   By: aljulien < aljulien@student.42lyon.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/13 16:52:14 by aljulien          #+#    #+#             */
-/*   Updated: 2025/03/19 16:34:03 by aljulien         ###   ########.fr       */
+/*   Updated: 2025/03/20 10:40:09 by aljulien         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,7 +28,7 @@ void kickFromAllMap(Client *target, Channel &curChan)
 		curChan.removeCli(INVITECLI, fdTarget);
 }
 
-void handleKick(CmdSpec &cmd)
+void kickExec(CmdSpec &cmd)
 {
 	Channel &curChan = findCurChan(cmd[channel][0]);
 	Client *sender = &cmd.getSender();

--- a/src/builder/command-execution/Mode.cpp
+++ b/src/builder/command-execution/Mode.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   Mode.cpp                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: aljulien <aljulien@student.42.fr>          +#+  +:+       +#+        */
+/*   By: aljulien < aljulien@student.42lyon.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/07 11:43:39 by aljulien          #+#    #+#             */
-/*   Updated: 2025/03/19 13:07:12 by aljulien         ###   ########.fr       */
+/*   Updated: 2025/03/19 16:36:19 by aljulien         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,21 +18,20 @@
 
 void executeO(std::string flag, std::string param, Channel &curChan)
 {
-	Client *target;
+	Client *targetCli;
 
 	//find instance of target
 	for (clientMapIt targetIt = curChan.getCliInChan().begin();
 		 targetIt != curChan.getCliInChan().end(); ++targetIt) {
 		if (targetIt->second->cliInfo.getNick() == param) {
-			target = targetIt->second;
+			targetCli = targetIt->second;
 			break;
 		}
 	}
 	if (flag == "+o")
-		curChan.getOpCli().insert(
-			std::pair< int, Client * >(target->getFd(), target));
+		curChan.addCli(OPCLI, targetCli);
 	if (flag == "-o")
-		curChan.getOpCli().erase(target->getFd());
+		curChan.removeCli(OPCLI, targetCli->getFd());
 }
 
 void executeI(std::string flag, std::string param, Channel &curChan)

--- a/src/builder/command-execution/Mode.cpp
+++ b/src/builder/command-execution/Mode.cpp
@@ -6,7 +6,7 @@
 /*   By: aljulien < aljulien@student.42lyon.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/07 11:43:39 by aljulien          #+#    #+#             */
-/*   Updated: 2025/03/19 16:36:19 by aljulien         ###   ########.fr       */
+/*   Updated: 2025/03/20 10:40:42 by aljulien         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -130,9 +130,9 @@ Channel &findCurChan(std::string chanName)
 }
 
 //the modes of a channel need to be empty if no moe is activated and +<modes> if any
-void handleMode(CmdSpec &cmd)
+void modeExec(CmdSpec &cmd)
 {
-	logLevel(DEBUG, "-----handleMode-----");
+	logLevel(DEBUG, "-----modeExec-----");
 	Client *sender = &cmd.getSender();
 	Channel &curChan = findCurChan(cmd[channel][0]);
 	std::string newModes;
@@ -143,7 +143,7 @@ void handleMode(CmdSpec &cmd)
 				  RPL_UMODEIS(sender->cliInfo.getNick(), curChan.getModes()));
 		return;
 	}
-	for (size_t nbFlag = 0; nbFlag < cmd[mode_].getSize(); ++nbFlag) {
+	for (size_t nbFlag = 0; nbFlag < cmd[mode_].getSize(); nbFlag++) {
 		if (cmd[mode_][nbFlag] == "+l")
 			newMaxCli = cmd[modeArg][nbFlag];
 		executeFlag(cmd[mode_][nbFlag], cmd[modeArg][nbFlag], curChan);

--- a/src/builder/command-execution/NickUser.cpp
+++ b/src/builder/command-execution/NickUser.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   NickUser.cpp                                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: aljulien <aljulien@student.42.fr>          +#+  +:+       +#+        */
+/*   By: aljulien < aljulien@student.42lyon.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/04 16:46:19 by aljulien          #+#    #+#             */
-/*   Updated: 2025/03/18 09:10:35 by aljulien         ###   ########.fr       */
+/*   Updated: 2025/03/20 10:41:22 by aljulien         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -42,7 +42,7 @@ void handleClientRegistration(const std::string &input, Client *curCli)
 			std::string pass;
 			std::istringstream passStream(line);
 			passStream >> pass >> pass;
-			handlePass(pass, curCli);
+			passExec(pass, curCli);
 		} else if (line.find("NICK") != std::string::npos) {
 			std::string nick;
 			std::istringstream nickStream(line);

--- a/src/builder/command-execution/Part.cpp
+++ b/src/builder/command-execution/Part.cpp
@@ -6,7 +6,7 @@
 /*   By: aljulien < aljulien@student.42lyon.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/10 09:12:52 by aljulien          #+#    #+#             */
-/*   Updated: 2025/03/19 16:44:58 by aljulien         ###   ########.fr       */
+/*   Updated: 2025/03/20 10:41:33 by aljulien         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,7 +14,7 @@
 #include "Reply.hpp"
 #include "Server.hpp"
 
-void handlePart(CmdSpec &cmd)
+void partExec(CmdSpec &cmd)
 {
 	Client *sender = &cmd.getSender();
 	Channel &curChan = findCurChan(cmd[channel][0]);

--- a/src/builder/command-execution/Part.cpp
+++ b/src/builder/command-execution/Part.cpp
@@ -6,7 +6,7 @@
 /*   By: aljulien < aljulien@student.42lyon.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/10 09:12:52 by aljulien          #+#    #+#             */
-/*   Updated: 2025/03/20 10:41:33 by aljulien         ###   ########.fr       */
+/*   Updated: 2025/03/20 10:55:01 by aljulien         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,6 +16,7 @@
 
 void partExec(CmdSpec &cmd)
 {
+	static Server &server = Server::GetServerInstance(0, "");
 	Client *sender = &cmd.getSender();
 	Channel &curChan = findCurChan(cmd[channel][0]);
 
@@ -28,9 +29,13 @@ void partExec(CmdSpec &cmd)
 						   RPL_PARTREASON(sender->cliInfo.getPrefix(),
 										  curChan.getName(), cmd[message][0]));
 
-	//TODO deleteEmptyChan 
+
 	int targetFd = sender->getFd();
 	curChan.removeCli(ALLCLI, targetFd);
 	if (curChan.getOpCli().find(targetFd) != curChan.getOpCli().end())
 		curChan.removeCli(OPCLI, targetFd);
+	if (curChan.getCliInChan().empty() == true) {
+		server.removeChan(&curChan);
+		delete &curChan;
+	}
 }

--- a/src/builder/command-execution/Part.cpp
+++ b/src/builder/command-execution/Part.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   Part.cpp                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: aljulien <aljulien@student.42.fr>          +#+  +:+       +#+        */
+/*   By: aljulien < aljulien@student.42lyon.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/10 09:12:52 by aljulien          #+#    #+#             */
-/*   Updated: 2025/03/19 12:48:54 by aljulien         ###   ########.fr       */
+/*   Updated: 2025/03/19 16:44:58 by aljulien         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,13 +28,9 @@ void handlePart(CmdSpec &cmd)
 						   RPL_PARTREASON(sender->cliInfo.getPrefix(),
 										  curChan.getName(), cmd[message][0]));
 
+	//TODO deleteEmptyChan 
 	int targetFd = sender->getFd();
-
-	curChan.getCliInChan().erase(targetFd);
-	logLevel(DEBUG, "erase client from channel");
-
-	if (curChan.getOpCli().find(targetFd) != curChan.getOpCli().end()) {
-		curChan.getOpCli().erase(targetFd);
-		logLevel(DEBUG, "erase client from op");
-	}
+	curChan.removeCli(ALLCLI, targetFd);
+	if (curChan.getOpCli().find(targetFd) != curChan.getOpCli().end())
+		curChan.removeCli(OPCLI, targetFd);
 }

--- a/src/builder/command-execution/Pass.cpp
+++ b/src/builder/command-execution/Pass.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   Pass.cpp                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: aljulien <aljulien@student.42.fr>          +#+  +:+       +#+        */
+/*   By: aljulien < aljulien@student.42lyon.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/17 09:04:38 by aljulien          #+#    #+#             */
-/*   Updated: 2025/03/19 12:52:41 by aljulien         ###   ########.fr       */
+/*   Updated: 2025/03/20 10:41:22 by aljulien         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,9 +14,9 @@
 #include "typedef.hpp"
 #include <sstream>
 
-bool handlePass(std::string params, Client *curCli)
+bool passExec(std::string params, Client *curCli)
 {
-	logLevel(DEBUG, "----handlePass----");
+	logLevel(DEBUG, "----passExec----");
 	static Server &server = Server::GetServerInstance(0, "");
 
 	std::istringstream iss(params);

--- a/src/builder/command-execution/Privmsg.cpp
+++ b/src/builder/command-execution/Privmsg.cpp
@@ -3,17 +3,17 @@
 /*                                                        :::      ::::::::   */
 /*   Privmsg.cpp                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: aljulien <aljulien@student.42.fr>          +#+  +:+       +#+        */
+/*   By: aljulien < aljulien@student.42lyon.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/04 16:52:37 by aljulien          #+#    #+#             */
-/*   Updated: 2025/03/19 12:46:43 by aljulien         ###   ########.fr       */
+/*   Updated: 2025/03/20 10:41:14 by aljulien         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "CmdSpec.hpp"
 #include "Server.hpp"
 
-void handlePrivsmg(CmdSpec &cmd)
+void privmsgExec(CmdSpec &cmd)
 {
 	static Server &server = Server::GetServerInstance(0, "");
 	Client *sender = &cmd.getSender();

--- a/src/builder/command-execution/Topic.cpp
+++ b/src/builder/command-execution/Topic.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   Topic.cpp                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: aljulien <aljulien@student.42.fr>          +#+  +:+       +#+        */
+/*   By: aljulien < aljulien@student.42lyon.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/05 10:55:57 by aljulien          #+#    #+#             */
-/*   Updated: 2025/03/19 12:48:16 by aljulien         ###   ########.fr       */
+/*   Updated: 2025/03/20 10:41:04 by aljulien         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -46,7 +46,7 @@ void changeTopic(Channel &curChan, Client *curCli, std::string topic)
 										curChan.getTopic()));
 }
 
-void handleTopic(CmdSpec &cmd)
+void topicExec(CmdSpec &cmd)
 {
 	Client *sender = &cmd.getSender();
 	Channel &curChan = findCurChan(cmd[channel][0]);

--- a/src/builder/command-execution/Who.cpp
+++ b/src/builder/command-execution/Who.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   Who.cpp                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: aljulien <aljulien@student.42.fr>          +#+  +:+       +#+        */
+/*   By: aljulien < aljulien@student.42lyon.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/14 14:08:17 by aljulien          #+#    #+#             */
-/*   Updated: 2025/03/18 17:00:47 by aljulien         ###   ########.fr       */
+/*   Updated: 2025/03/20 10:40:54 by aljulien         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,7 +14,7 @@
 #include "Server.hpp"
 #include <sstream>
 
-bool handleWho(std::string params, Client *curCli)
+bool whoExec(std::string params, Client *curCli)
 {
 	static Server &server = Server::GetServerInstance(0, "");
 

--- a/src/builder/command-validation/CmdManager.cpp
+++ b/src/builder/command-validation/CmdManager.cpp
@@ -77,7 +77,7 @@ void CmdManager::generateCmds()
 			.Parameters(channel, new CmdParam(false, ','))
 			.Parameters(key, new CmdParam(true, ',')) //TODO : TRUE = OPTIONNEL
 			.addChecker(joinChanRequest)
-			.CmExecutor(handleJoin)
+			.CmExecutor(joinExec)
 			.build());
 
 	//can have 0 params or 2
@@ -91,7 +91,7 @@ void CmdManager::generateCmds()
 			.addChecker(onChan)
 			.addChecker(validInvite)
 			.addChecker(hasChanPriv)
-			.CmExecutor(handleInvite)
+			.CmExecutor(inviteExec)
 			.build());
 
 	//si un target est faux on fait pas ceux qui suivent
@@ -106,7 +106,7 @@ void CmdManager::generateCmds()
 			.addChecker(hasChanPriv)
 			.addChecker(validTarget)
 			.addChecker(validKick)
-			.CmExecutor(handleKick)
+			.CmExecutor(kickExec)
 			.build());
 
 	log(CmdSpec::CmdBuilder()
@@ -119,7 +119,7 @@ void CmdManager::generateCmds()
 			.addChecker(hasChanPriv)
 			.addChecker(validMode)
 			// .addChecker(validArg) ?
-			.CmExecutor(handleMode)
+			.CmExecutor(modeExec)
 			.build());
 
 	log(CmdSpec::CmdBuilder()
@@ -129,7 +129,7 @@ void CmdManager::generateCmds()
 			.Parameters(message, new CmdParam(true, '\0'))
 			.addChecker(validChan)
 			.addChecker(onChan)
-			.CmExecutor(handlePart)
+			.CmExecutor(partExec)
 			.build());
 
 	//we want ERR_NORECIPIENT not ERR_NEEDMOREPARAMS
@@ -140,7 +140,7 @@ void CmdManager::generateCmds()
 			.Parameters(message, new CmdParam())
 			.addChecker(validMess)
 			.addChecker(validTarget)
-			.CmExecutor(handlePrivsmg)
+			.CmExecutor(privmsgExec)
 			.build());
 
 	log(CmdSpec::CmdBuilder()
@@ -158,7 +158,7 @@ void CmdManager::generateCmds()
 			.addChecker(validChan)
 			.addChecker(onChan)
 			.addChecker(hasChanPriv) //(only if mode +t is set)
-			.CmExecutor(handleTopic)
+			.CmExecutor(topicExec)
 			.build());
 }
 

--- a/src/server/Channel.cpp
+++ b/src/server/Channel.cpp
@@ -6,7 +6,7 @@
 /*   By: aljulien < aljulien@student.42lyon.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/26 14:31:43 by aljulien          #+#    #+#             */
-/*   Updated: 2025/03/19 16:16:12 by aljulien         ###   ########.fr       */
+/*   Updated: 2025/03/19 16:23:58 by aljulien         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -51,8 +51,9 @@ bool Channel::addClientToChan(Channel *curChan, Client *curCli)
 			return (false);
 		}
 	if (curChan->getCliInChan().empty())
-		curChan->getOpCli().insert(clientPair(curCli->getFd(), curCli));
-	curChan->getCliInChan().insert(clientPair(curCli->getFd(), curCli));
+		curChan->addCli(OPCLI, curCli);
+	curChan->addCli(ALLCLI, curCli);
+
 	curCli->getJoinedChans().push_back(curChan->getName());
 
 	//messageToAllChannel
@@ -188,5 +189,3 @@ void Channel::setTopicRestrict(bool topicRestrict)
 {
 	topicRestrict_ = topicRestrict;
 }
-
-"C_Cpp.clang_format_style": "{BasedOn: GNU, UseTab: Always, IndentWidth: 4, TabWidth: 4, ReflowComments: false, AllowShortBlocksOnASingleLine: true, AllowShortFunctionsOnASingleLine: Empty, SplitEmptyFunction: false, AlwaysBreakTemplateDeclarations: Yes, BraceWrapping: {AfterControlStatement: false, BeforeCatch: false, AfterFunction: false}, BreakBeforeBraces: Custom, MaxEmptyLinesToKeep: 1, SpacesInAngles: true, ColumnLimit: 80, NamespaceIndentation: All}",

--- a/src/server/Channel.cpp
+++ b/src/server/Channel.cpp
@@ -6,7 +6,7 @@
 /*   By: aljulien < aljulien@student.42lyon.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/26 14:31:43 by aljulien          #+#    #+#             */
-/*   Updated: 2025/03/20 10:14:07 by aljulien         ###   ########.fr       */
+/*   Updated: 2025/03/20 10:50:45 by aljulien         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,7 +26,7 @@ Channel::Channel(std::string name)
 
 Channel::~Channel(void)
 {
-	// logLevel(INFO, "Channel deleted:", this->getName());
+	logLevel(INFO, "Channel deleted:", this->getName());
 }
 
 /* ************************************************************************** */

--- a/src/server/Channel.cpp
+++ b/src/server/Channel.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   Channel.cpp                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: aljulien <aljulien@student.42.fr>          +#+  +:+       +#+        */
+/*   By: aljulien < aljulien@student.42lyon.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/26 14:31:43 by aljulien          #+#    #+#             */
-/*   Updated: 2025/03/18 09:11:17 by aljulien         ###   ########.fr       */
+/*   Updated: 2025/03/19 16:16:12 by aljulien         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -67,6 +67,32 @@ bool Channel::addClientToChan(Channel *curChan, Client *curCli)
 				  RPL_TOPIC(curCli->cliInfo.getNick(), curChan->getName(),
 							curChan->getTopic()));
 	return (true);
+}
+
+void Channel::addCli(mapChan curMap, Client *curCli) {
+	switch (curMap) {
+		case ALLCLI:
+			cliInChan_.insert(clientPair(curCli->getFd(), curCli));
+			break ;
+		case OPCLI:
+			cliIsOperator_.insert(clientPair(curCli->getFd(), curCli));
+			break ;
+		case INVITECLI:
+			cliInvited_.insert(clientPair(curCli->getFd(), curCli));
+	}
+}
+
+void Channel::removeCli(mapChan curMap, int fdCli) {
+	switch (curMap) {
+		case ALLCLI:
+			cliInChan_.erase(fdCli);
+			break ;
+		case OPCLI:
+			cliIsOperator_.erase(fdCli);
+			break ;
+		case INVITECLI:
+			cliInvited_.erase(fdCli);
+	}
 }
 
 /* ************************************************************************** */
@@ -162,3 +188,5 @@ void Channel::setTopicRestrict(bool topicRestrict)
 {
 	topicRestrict_ = topicRestrict;
 }
+
+"C_Cpp.clang_format_style": "{BasedOn: GNU, UseTab: Always, IndentWidth: 4, TabWidth: 4, ReflowComments: false, AllowShortBlocksOnASingleLine: true, AllowShortFunctionsOnASingleLine: Empty, SplitEmptyFunction: false, AlwaysBreakTemplateDeclarations: Yes, BraceWrapping: {AfterControlStatement: false, BeforeCatch: false, AfterFunction: false}, BreakBeforeBraces: Custom, MaxEmptyLinesToKeep: 1, SpacesInAngles: true, ColumnLimit: 80, NamespaceIndentation: All}",

--- a/src/server/Channel.cpp
+++ b/src/server/Channel.cpp
@@ -6,7 +6,7 @@
 /*   By: aljulien < aljulien@student.42lyon.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/26 14:31:43 by aljulien          #+#    #+#             */
-/*   Updated: 2025/03/20 10:50:45 by aljulien         ###   ########.fr       */
+/*   Updated: 2025/03/20 11:05:27 by aljulien         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -44,7 +44,7 @@ void sendMessageChannel(clientMap allCliChannel, std::string message)
 bool Channel::addClientToChan(Channel *curChan, Client *curCli)
 {
 	// logLevel(DEBUG, "-----addClientToChan-----");
-	std::map< int, Client * > &clients = curChan->getCliInChan();
+	std::map< int, Client * > clients = curChan->getCliInChan();
 	for (clientMapIt it = clients.begin(); it != clients.end(); ++it)
 		if (curCli == it->second) {
 			// logLevel(INFO, "Client already in channel");
@@ -124,15 +124,15 @@ bool Channel::getTopicRestrict() const
 {
 	return (topicRestrict_);
 }
-clientMap &Channel::getCliInChan()
+const clientMap &Channel::getCliInChan() const
 {
 	return (cliInChan_);
 }
-clientMap &Channel::getOpCli()
+const clientMap &Channel::getOpCli() const
 {
 	return (cliIsOperator_);
 }
-clientMap &Channel::getInvitCli()
+const clientMap &Channel::getInvitCli() const
 {
 	return (cliInvited_);
 }

--- a/src/server/Channel.cpp
+++ b/src/server/Channel.cpp
@@ -6,7 +6,7 @@
 /*   By: aljulien < aljulien@student.42lyon.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/26 14:31:43 by aljulien          #+#    #+#             */
-/*   Updated: 2025/03/19 16:23:58 by aljulien         ###   ########.fr       */
+/*   Updated: 2025/03/20 10:14:07 by aljulien         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,7 +18,7 @@
 /* ************************************************************************** */
 
 Channel::Channel(std::string name)
-	: inviteOnly_(false), isPassMatch_(false), topicRestrict_(true), maxCli_(0),
+	: inviteOnly_(true), isPassMatch_(false), topicRestrict_(true), maxCli_(0),
 	  name_(name), topic_("")
 {
 	setModes();

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -6,7 +6,7 @@
 /*   By: aljulien < aljulien@student.42lyon.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/18 15:25:39 by aljulien          #+#    #+#             */
-/*   Updated: 2025/03/20 10:57:40 by aljulien         ###   ########.fr       */
+/*   Updated: 2025/03/20 11:12:07 by aljulien         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -213,7 +213,7 @@ bool checkOnlyOperator(int fd)
 {
 	static Server &server = Server::GetServerInstance(0, "");
 
-	clientMap::iterator curCli = server.getAllCli().find(fd);
+	clientMap::const_iterator curCli = server.getAllCli().find(fd);
 	//joinExec("0", curCli->second);
 	for (stringVec::iterator curChanName =
 			 curCli->second->getJoinedChans().begin();
@@ -266,11 +266,11 @@ Server::InitFailed::InitFailed(const char *err) : errMessage(err) {}
 /* ************************************************************************** */
 /*                               GETTERS                                      */
 /* ************************************************************************** */
-clientMap &Server::getAllCli()
+const clientMap &Server::getAllCli() const
 {
 	return (clients_);
 }
-channelMap &Server::getAllChan()
+const channelMap &Server::getAllChan() const
 {
 	return (channels_);
 }

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -6,7 +6,7 @@
 /*   By: aljulien < aljulien@student.42lyon.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/18 15:25:39 by aljulien          #+#    #+#             */
-/*   Updated: 2025/03/20 10:40:31 by aljulien         ###   ########.fr       */
+/*   Updated: 2025/03/20 10:57:40 by aljulien         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -225,6 +225,11 @@ bool checkOnlyOperator(int fd)
 				curChan->second->addCli(OPCLI, curChan->second->getCliInChan().begin()->second);
 				return (true);
 			}
+			//delete chan if the disconnected cli was the one cli in chan
+			if (curChan->second->getCliInChan().empty() == true) {
+				server.removeChan(curChan->second);
+				delete curChan->second;
+			}
 		}
 	}
 	return (false);
@@ -236,7 +241,6 @@ bool Server::disconnectCli(int fd)
 	checkOnlyOperator(fd);
 	clientMapIt it = clients_.find(fd);
 	if (it != clients_.end()) {
-		//TODO deleteEmptyChan 
 		std::stringstream ss;
 		ss << "Client [" << it->second->getFd() << "] connected";
 		logLevel(INFO, ss.str());

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   Server.cpp                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: aljulien <aljulien@student.42.fr>          +#+  +:+       +#+        */
+/*   By: aljulien < aljulien@student.42lyon.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/18 15:25:39 by aljulien          #+#    #+#             */
-/*   Updated: 2025/03/18 17:07:34 by aljulien         ###   ########.fr       */
+/*   Updated: 2025/03/19 15:45:20 by aljulien         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -199,6 +199,14 @@ void Server::processBuffer(Client *curCli)
 		}
 	}
 }
+
+void Server::addCli(int fdCli) {}
+
+void Server::removeCli(int fdCli) {}
+
+void Server::addChan(std::string nameChan) {}
+
+void Server::removeChan(std::string nameChan) {}
 
 bool checkOnlyOperator(int fd)
 {

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -6,7 +6,7 @@
 /*   By: aljulien < aljulien@student.42lyon.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/18 15:25:39 by aljulien          #+#    #+#             */
-/*   Updated: 2025/03/19 16:44:49 by aljulien         ###   ########.fr       */
+/*   Updated: 2025/03/20 10:40:31 by aljulien         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -214,7 +214,7 @@ bool checkOnlyOperator(int fd)
 	static Server &server = Server::GetServerInstance(0, "");
 
 	clientMap::iterator curCli = server.getAllCli().find(fd);
-	//handleJoin("0", curCli->second);
+	//joinExec("0", curCli->second);
 	for (stringVec::iterator curChanName =
 			 curCli->second->getJoinedChans().begin();
 		 curChanName != curCli->second->getJoinedChans().end();

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -6,7 +6,7 @@
 /*   By: aljulien < aljulien@student.42lyon.fr>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/02/18 15:25:39 by aljulien          #+#    #+#             */
-/*   Updated: 2025/03/19 15:45:20 by aljulien         ###   ########.fr       */
+/*   Updated: 2025/03/19 16:44:49 by aljulien         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -200,13 +200,14 @@ void Server::processBuffer(Client *curCli)
 	}
 }
 
-void Server::addCli(int fdCli) {}
+void Server::addChan(Channel *curChan) {
+	channels_.insert(std::pair<std::string, Channel *>(curChan->getName(), curChan));
+}
 
-void Server::removeCli(int fdCli) {}
+void Server::removeChan(Channel *curChan) {
+	channels_.erase(curChan->getName());
+}
 
-void Server::addChan(std::string nameChan) {}
-
-void Server::removeChan(std::string nameChan) {}
 
 bool checkOnlyOperator(int fd)
 {
@@ -214,16 +215,14 @@ bool checkOnlyOperator(int fd)
 
 	clientMap::iterator curCli = server.getAllCli().find(fd);
 	//handleJoin("0", curCli->second);
-	for (stringVec::iterator currChanName =
+	for (stringVec::iterator curChanName =
 			 curCli->second->getJoinedChans().begin();
-		 currChanName != curCli->second->getJoinedChans().end();
-		 ++currChanName) {
-		channelMapIt currChan = server.getAllChan().find(*currChanName);
-		if (!currChan->second->getOpCli().size()) {
-			if (currChan->second->getCliInChan().size() >= 1) {
-				currChan->second->getOpCli().insert(clientPair(
-					currChan->second->getCliInChan().begin()->second->getFd(),
-					currChan->second->getCliInChan().begin()->second));
+		 curChanName != curCli->second->getJoinedChans().end();
+		 ++curChanName) {
+		channelMapIt curChan = server.getAllChan().find(*curChanName);
+		if (!curChan->second->getOpCli().size()) {
+			if (curChan->second->getCliInChan().size() >= 1) {
+				curChan->second->addCli(OPCLI, curChan->second->getCliInChan().begin()->second);
 				return (true);
 			}
 		}
@@ -237,6 +236,7 @@ bool Server::disconnectCli(int fd)
 	checkOnlyOperator(fd);
 	clientMapIt it = clients_.find(fd);
 	if (it != clients_.end()) {
+		//TODO deleteEmptyChan 
 		std::stringstream ss;
 		ss << "Client [" << it->second->getFd() << "] connected";
 		logLevel(INFO, ss.str());
@@ -247,7 +247,6 @@ bool Server::disconnectCli(int fd)
 	}
 	return false;
 }
-
 /* ************************************************************************** */
 /*                               EXCEPTIONS                                   */
 /* ************************************************************************** */


### PR DESCRIPTION
Added the addCLient/removeClient methods in the Channel class. We use those for map modifying
The getters of the :
-cliInChan_
-cliIsOperator_
-cliInvited_
map in Channel are now in full const. 
Added the addChannel/removeChannel methods in the Server class. We use those for map modifying
The getters of the :
-channels_
map is now in full const.

Changes the typedef iterator of : 
-ClientMapIt
-channelMapIt
to const_iterator to match the const return of the getters of the different maps across Channel and Server class. 

Changed the names of execution function from :
handleCmd
to :
cmdExec