### PR TITLE
Refacto/api/findCurlPath

### DIFF
--- a/.make/bot_src.mk
+++ b/.make/bot_src.mk
@@ -12,6 +12,7 @@ SRC_ROOT:=	Bot.cpp \
 			Message.cpp \
 			Cmd.cpp \
 			Api.cpp \
+			Utils.cpp \
 
 # ----------------------------- BOT FILE BUILDING PATH ----------------------- #
 

--- a/bot/headers/Api.hpp
+++ b/bot/headers/Api.hpp
@@ -27,7 +27,8 @@
 #include <unistd.h>
 #include <vector>
 #include "Reply.hpp"
-# include <cstdlib>
+#include <cstdlib>
+#include "Utils.hpp"
 
 class Api {
   public:

--- a/bot/headers/Message.hpp
+++ b/bot/headers/Message.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <unistd.h>
 #include <vector>
+#include "Utils.hpp"
 
 typedef std::vector< std::string > stringVec;
 
@@ -18,7 +19,6 @@ class Msg {
 	/*                               METHODS                                  */
 	bool processBuf();
 	std::string::size_type evalTerm() const;
-	stringVec vectorSplit(char del);
 	void clear();
 	void removeNl();
 	bool rplIs(const std::string &expected) const;

--- a/bot/headers/Utils.hpp
+++ b/bot/headers/Utils.hpp
@@ -1,0 +1,9 @@
+//HEADER
+
+#include <vector>
+#include <string>
+#include <sstream>
+
+typedef std::vector< std::string > stringVec;
+
+stringVec vectorSplit(std::string &rcv, char del);

--- a/bot/src/Api.cpp
+++ b/bot/src/Api.cpp
@@ -208,7 +208,7 @@ bool Api::findCurlPath() {
 		curlPath_ += "/curl";
 		if (access(curlPath_.c_str(), X_OK) == 0)
 			return (true);
-		pathVar.erase(0, i + 1);
+		pathVar.erase(0, pos + 1);
 		curlPath_.clear();
 	}
 	RPL::log(RPL::ERROR, "could not find path\r\n");

--- a/bot/src/Api.cpp
+++ b/bot/src/Api.cpp
@@ -198,17 +198,11 @@ bool Api::findCurlPath() {
 		RPL::log(RPL::ERROR, "could not find path\r\n");
 		return (false);
 	}
-
-	size_t pos = 0;
-	for (size_t i = 0; i < pathVar.size(); i++) {
-		pos = pathVar.find(":");
-		if (pos == std::string::npos)
-			pos = pathVar.size();
-		curlPath_.assign(pathVar, 0, pos);
-		curlPath_ += "/curl";
+	stringVec paths = vectorSplit(pathVar, ':');
+	for (size_t i = 0; i < paths.size(); i++) {
+		curlPath_ = paths[i] + "/curl";
 		if (access(curlPath_.c_str(), X_OK) == 0)
 			return (true);
-		pathVar.erase(0, pos + 1);
 		curlPath_.clear();
 	}
 	RPL::log(RPL::ERROR, "could not find path\r\n");

--- a/bot/src/Message.cpp
+++ b/bot/src/Message.cpp
@@ -38,7 +38,7 @@ ssize_t Msg::_recv(const int fd) {
 bool Msg::processBuf() {
 	removeNl();
 	trimConsecutiveSpaces();
-	cmdParam_ = vectorSplit(' ');
+	cmdParam_ = vectorSplit(rcv_, ' ');
 	trimUsername();
 	return true;
 }
@@ -75,16 +75,6 @@ void Msg::trimConsecutiveSpaces() {
 		std::unique(rcv_.begin(), rcv_.end(), isConsecutiveSpace);
 	if (newEnd != rcv_.end())
 		rcv_.erase(newEnd, rcv_.end());
-}
-
-stringVec Msg::vectorSplit(char del) {
-	stringVec result;
-	std::string token;
-
-	std::istringstream stream(rcv_);
-	while (std::getline(stream, token, del))
-		result.push_back(token);
-	return (result);
 }
 
 void Msg::clear() {

--- a/bot/src/Utils.cpp
+++ b/bot/src/Utils.cpp
@@ -1,0 +1,13 @@
+//HEADER
+
+#include "Utils.hpp"
+
+stringVec vectorSplit(std::string &rcv, char del) {
+	stringVec result;
+	std::string token;
+
+	std::istringstream stream(rcv);
+	while (std::getline(stream, token, del))
+		result.push_back(token);
+	return (result);
+}


### PR DESCRIPTION
- add new file Utils
- moved vectorSplit from Message.hpp to Utils.hpp
- used vectorSplit in findCurlPath instead of std::string find and erase methods

//branch can be deleted